### PR TITLE
Python tgz deployment

### DIFF
--- a/mendel/__init__.py
+++ b/mendel/__init__.py
@@ -48,10 +48,12 @@ def init(service_name=None, bundle_type=None, project_type=None):
     else:
         build_target_path = 'target/%s' % service_name
 
-    project_type = project_type or raw_input('enter project_type type (java) [java]: ') or 'java'
+    project_type = project_type or raw_input('enter project_type type (java, python) [java]: ') or 'java'
     if project_type != 'java':
-        red('if you want project_type %s, issue a pull request.' % project_type)
-        sys.exit(1)
+        if bundle_type != 'tgz':
+            if project_type != 'python':
+                red('if you want project_type %s, issue a pull request.' % project_type)
+                sys.exit(1)
 
     conf = OrderedDict()
     conf['service_name'] = service_name

--- a/mendel/__init__.py
+++ b/mendel/__init__.py
@@ -49,11 +49,12 @@ def init(service_name=None, bundle_type=None, project_type=None):
         build_target_path = 'target/%s' % service_name
 
     project_type = project_type or raw_input('enter project_type type (java, python) [java]: ') or 'java'
-    if project_type != 'java':
-        if bundle_type != 'tgz':
-            if project_type != 'python':
-                red('if you want project_type %s, issue a pull request.' % project_type)
-                sys.exit(1)
+    if project_type not in ('java', 'python'):
+        red('if you want project_type %s, issue a pull request.' % bundle_type)
+        sys.exit(1)
+    if project_type == 'python' and bundle_type != 'tgz':
+        red('if you want project_type {} to use {}, issue a pull request.'.format(project_type, bundle_type))
+        sys.exit(1)
 
     conf = OrderedDict()
     conf['service_name'] = service_name

--- a/mendel/core.py
+++ b/mendel/core.py
@@ -138,9 +138,14 @@ class Mendel(object):
         # will probably want a builder delegate and a deployer delegate
         # because cross products
         if bundle_type == 'tgz':
-            self._install = self._install_tgz
-            self._upload = self._upload_tgz
-            self._rollback = self._symlink_rollback
+            if project_type == 'python':
+                self._install = self._install_tgz
+                self._upload = self._upload_tgz
+                self._rollback = self._symlink_rollback
+            else:
+                self._install = self._install_tgz
+                self._upload = self._upload_tgz
+                self._rollback = self._symlink_rollback
         elif bundle_type == 'deb':
             self._install = self._install_deb
             self._upload = self._upload_deb
@@ -366,8 +371,25 @@ class Mendel(object):
             # so we can delete it after extraction
             sudo('chown %s:%s %s' % (self._user, self._group, bundle_file))
             sudo('tar --strip-components 1 -zxvf %(bf)s && rm %(bf)s' % {'bf': bundle_file}, user=self._user, group=self._group)
-            sudo('ln -sf *.jar %s.jar' % self._service_name, user=self._user, group=self._group)
-            self._change_symlink_to(self._rpath('releases', release_dir))
+
+            if self._project_type == 'java':
+                sudo('ln -sf *.jar %s.jar' % self._service_name, user=self._user, group=self._group)
+                self._change_symlink_to(self._rpath('releases', release_dir))
+            
+            elif self._project_type == 'python':
+                # fabric commands are each issued in their own shell so the virtual env needs to be activated each time
+                # pip had issues with wheel cache permissions which were solved wit hthe --no-cache flag
+                # the requires.txt is used instead of setup.py install because we don't need the code installed as a module
+                #   but we still need to the requirements isntalled, this way we dont have to find a requirements.txt file
+                #   in the rest of the application b/c setup.py sdist puts it in the egg-info
+                sudo('source /srv/{srv_name}/env/bin/activate && pip install --no-cache -r {rel_dir}/{srv_name}.egg-info/requires.txt'
+                        .format(srv_name=self._service_name, rel_dir=self._rpath('releases', release_dir)),
+                        user=self._user,
+                        group=self._group)
+                # need to get the top level application directory but not the egg-info directory or other setup files
+                project_dir = sudo("find . -maxdepth 1 -mindepth 1 -type d -not -regex '.*egg-info$'")
+                project_dir = project_dir[2:]  # find command returns a string like './dir'
+                self._change_symlink_to(self._rpath('releases', release_dir, project_dir))
 
     def _install_jar(self, jar_name):
         release_dir = self._new_release_dir()
@@ -580,6 +602,9 @@ class Mendel(object):
         if not self._is_already_built():
             if self._project_type == "java":
                 local('mvn clean -U package')
+            if self._project_type == "python":
+                if self._bundle_type == "tgz":
+                    local('python setup.py sdist')
             else:
                 raise Exception("Unsupported project type: %s" % self._project_type)
             self._mark_as_built()

--- a/mendel/core.py
+++ b/mendel/core.py
@@ -138,14 +138,9 @@ class Mendel(object):
         # will probably want a builder delegate and a deployer delegate
         # because cross products
         if bundle_type == 'tgz':
-            if project_type == 'python':
-                self._install = self._install_tgz
-                self._upload = self._upload_tgz
-                self._rollback = self._symlink_rollback
-            else:
-                self._install = self._install_tgz
-                self._upload = self._upload_tgz
-                self._rollback = self._symlink_rollback
+            self._install = self._install_tgz
+            self._upload = self._upload_tgz
+            self._rollback = self._symlink_rollback
         elif bundle_type == 'deb':
             self._install = self._install_deb
             self._upload = self._upload_deb
@@ -370,6 +365,7 @@ class Mendel(object):
         with cd(self._rpath('releases', release_dir)):
             # so we can delete it after extraction
             sudo('chown %s:%s %s' % (self._user, self._group, bundle_file))
+            
             sudo('tar --strip-components 1 -zxvf %(bf)s && rm %(bf)s' % {'bf': bundle_file}, user=self._user, group=self._group)
 
             if self._project_type == 'java':
@@ -378,9 +374,9 @@ class Mendel(object):
             
             elif self._project_type == 'python':
                 # fabric commands are each issued in their own shell so the virtual env needs to be activated each time
-                # pip had issues with wheel cache permissions which were solved wit hthe --no-cache flag
+                # pip had issues with wheel cache permissions which were solved with the --no-cache flag
                 # the requires.txt is used instead of setup.py install because we don't need the code installed as a module
-                #   but we still need to the requirements isntalled, this way we dont have to find a requirements.txt file
+                #   but we still need to the requirements installed, this way we dont have to find a requirements.txt file
                 #   in the rest of the application b/c setup.py sdist puts it in the egg-info
                 sudo('source /srv/{srv_name}/env/bin/activate && pip install --no-cache -r {rel_dir}/{srv_name}.egg-info/requires.txt'
                         .format(srv_name=self._service_name, rel_dir=self._rpath('releases', release_dir)),
@@ -605,6 +601,8 @@ class Mendel(object):
             if self._project_type == "python":
                 if self._bundle_type == "tgz":
                     local('python setup.py sdist')
+                else:
+                    raise Exception("Unsupported bundle type: {} for project type: {}".format(self._bundle_type, self._project_type))
             else:
                 raise Exception("Unsupported project type: %s" % self._project_type)
             self._mark_as_built()


### PR DESCRIPTION
Assumes `mendel deploy` will be run from within a python project with top level directory containing all of the application code and a `setup.py` file with `install_requires` containing all necessary modules.

Packages as a tar.gz, uploads and unpacks to the `releases` path on the server, then symlinks `current` to the root of the project. Does not use `setup.py install` in order to keep code out of `site-packages` or having to deal with install prefixes but does use the requires file generated during the packaging process.

