### PR TITLE
added make release

### DIFF
--- a/makefile
+++ b/makefile
@@ -1,8 +1,20 @@
+version = $(shell egrep -o "[0-9]+\.[0-9]+\.[0-9]+" mendel/version.py)
+
 init:
 	pip install -r requirements.txt
 
 test:
 	tox
+
+release: test
+	@echo "releasing version $(version)..."
+	# only allow releasing from master branch
+	[[ "`git rev-parse --abbrev-ref HEAD`" == "master" ]]
+	# if tag fails, that means we're trying to build
+	# a version that already exists
+	git tag $(version)
+	git push origin $(version)
+	python setup.py sdist upload -r sprout
 
 clean:
 	rm -rf ./dist/


### PR DESCRIPTION
makes it so you can’t release to pypi w/o being in the master branch and without tagging the release first and pushing to github …and running tests first
and if you try to tag a release that’s already been released, it’ll also fail cuz you cant create the same git tag twice