### PR TITLE
Fix pyCharm integration testing & requirement parsing

### DIFF
--- a/mendel/util.py
+++ b/mendel/util.py
@@ -129,7 +129,7 @@ def is_running_tests():
     the unittests are being run.
     :return: bool
     """
-    test_heuristics = ['python -m unittest', 'setup.py', 'utrunner.py']
+    test_heuristics = ['python -m unittest', 'setup.py', 'utrunner.py', 'PyCharm.app']
 
     running_tests = False
     for arg in sys.argv:

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,10 @@ try:
 except ImportError:
     from distutils.core import setup
 
-from pip.req import parse_requirements
+def parse_requirements(filename):
+    """ load requirements from a pip requirements file """
+    lineiter = (line.strip() for line in open(filename))
+    return [line for line in lineiter if line and not line.startswith("#")]
 
 # place __version__ in setup.py namespace, w/o
 # having to import and creating a dependency nightmare
@@ -24,12 +27,12 @@ reqs_file = os.path.join(package_dir, 'requirements.txt')
 
 # stupid session thing. stealing tweepy's solution:
 # https://github.com/tweepy/tweepy/commit/9b4cb9eb123be05a925c1c6deaf0141699853644
-install_reqs = parse_requirements(reqs_file, session=uuid.uuid1())
+install_reqs = parse_requirements(reqs_file)
 
 
 setup(
     name='fabric-mendel',
-    install_requires=[str(ir.req) for ir in install_reqs],
+    install_requires=[str(ir) for ir in install_reqs],
     version=__version__, # comes from execfile() invocation above; IDEs will complain.
     description='Fabric Tooling for deploying services',
     author='Sprout Social, Inc.',

--- a/setup.py
+++ b/setup.py
@@ -25,8 +25,6 @@ package_dir = \
 
 reqs_file = os.path.join(package_dir, 'requirements.txt')
 
-# stupid session thing. stealing tweepy's solution:
-# https://github.com/tweepy/tweepy/commit/9b4cb9eb123be05a925c1c6deaf0141699853644
 install_reqs = parse_requirements(reqs_file)
 
 


### PR DESCRIPTION
`pip.req` doesn't seem to be a thing anymore, so I removed its import statement & replaced it with an implementation of `parse_requirements`. Also, during Kevin & my pairing session, we realized integration testing with pyCharm wasn't working. So we added part of pyCharm's parameter URL in the symbol table to our test heuristics.